### PR TITLE
Exclude `*.config.js` files from repo lang stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,6 @@
 # - https://git-scm.com/docs/gitattributes#_end_of_line_conversion.
 # - https://aleksandrhovhannisyan.com/blog/crlf-vs-lf-normalizing-line-endings-in-git/#normalizing-line-endings-in-git-with-gitattributes.
 * text=auto
+
+# Excluded files and directories from GitHub language statistics.
+*.config.js linguist-vendored

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
+### Prettier ###
+# By default, Prettier ignores files in:
+# - version control systems directories (".git", ".sl", ".svn" and ".hg")
+# - node_modules
+# Prettier will also follow rules specified in the ".gitignore" file if it exists in the same directory from which it is run.
+# Reference: https://prettier.io/docs/en/ignore.html.
+
+# --------------------------------------------------------------------------------
+
 # Created by https://www.toptal.com/developers/gitignore/api/git,node
 # Edit at https://www.toptal.com/developers/gitignore?templates=git,node
 


### PR DESCRIPTION
# Before

<img width="325" alt="Screenshot 2024-10-22 at 09 00 40" src="https://github.com/user-attachments/assets/656cd128-b9d8-4f86-85b6-bf0ccf8640a5">
<img width="747" alt="Screenshot 2024-10-22 at 09 00 27" src="https://github.com/user-attachments/assets/84c056d6-986e-49e3-90de-0baf8424f0c5">

# After

