### PR TITLE
Revert "Make Stylelint lint HTML & HTML-like files (#140)"

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,16 +10,6 @@
 	// Lint CSS with Stylelint
 	// Disable VS Code's built-in linters to prevent them from reporting the same errors as Stylelint
 	"stylelint.enable": true, // default
-	"stylelint.validate": [
-		"css", // default
-		"postcss", // default
-		"astro",
-		"html",
-		"php",
-		"svelte",
-		"vue",
-		"xml"
-	],
 	"css.validate": false,
 	"less.validate": false,
 	"scss.validate": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,10 +15,8 @@
 				"husky": "9.1.6",
 				"lint-staged": "15.2.10",
 				"markdownlint-cli2": "0.15.0",
-				"postcss-html": "1.7.0",
 				"prettier": "3.3.3",
 				"stylelint": "16.10.0",
-				"stylelint-config-html": "1.1.0",
 				"stylelint-config-recess-order": "5.1.1",
 				"stylelint-config-standard": "36.0.1",
 				"stylelint-plugin-defensive-css": "1.0.4"
@@ -909,65 +907,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/dom-serializer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.2",
-				"entities": "^4.2.0"
-			},
-			"funding": {
-				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-			}
-		},
-		"node_modules/domelementtype": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fb55"
-				}
-			],
-			"license": "BSD-2-Clause"
-		},
-		"node_modules/domhandler": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"domelementtype": "^2.3.0"
-			},
-			"engines": {
-				"node": ">= 4"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/domhandler?sponsor=1"
-			}
-		},
-		"node_modules/domutils": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-			"integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"dom-serializer": "^2.0.0",
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.3"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/domutils?sponsor=1"
-			}
-		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -1458,26 +1397,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/htmlparser2": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-			"integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
-			"dev": true,
-			"funding": [
-				"https://github.com/fb55/htmlparser2?sponsor=1",
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fb55"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.3",
-				"domutils": "^3.0.1",
-				"entities": "^4.4.0"
 			}
 		},
 		"node_modules/human-signals": {
@@ -2365,46 +2284,6 @@
 				"node": "^10 || ^12 || >=14"
 			}
 		},
-		"node_modules/postcss-html": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-1.7.0.tgz",
-			"integrity": "sha512-MfcMpSUIaR/nNgeVS8AyvyDugXlADjN9AcV7e5rDfrF1wduIAGSkL4q2+wgrZgA3sHVAHLDO9FuauHhZYW2nBw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"htmlparser2": "^8.0.0",
-				"js-tokens": "^9.0.0",
-				"postcss": "^8.4.0",
-				"postcss-safe-parser": "^6.0.0"
-			},
-			"engines": {
-				"node": "^12 || >=14"
-			}
-		},
-		"node_modules/postcss-html/node_modules/js-tokens": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.0.tgz",
-			"integrity": "sha512-WriZw1luRMlmV3LGJaR6QOJjWwgLUTf89OwT2lUOyjX2dJGBwgmIkbcz+7WFZjrZM635JOIR517++e/67CP9dQ==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/postcss-html/node_modules/postcss-safe-parser": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
-			"integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/postcss/"
-			},
-			"peerDependencies": {
-				"postcss": "^8.3.3"
-			}
-		},
 		"node_modules/postcss-resolve-nested-selector": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.6.tgz",
@@ -2802,23 +2681,6 @@
 			},
 			"engines": {
 				"node": ">=18.12.0"
-			}
-		},
-		"node_modules/stylelint-config-html": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-html/-/stylelint-config-html-1.1.0.tgz",
-			"integrity": "sha512-IZv4IVESjKLumUGi+HWeb7skgO6/g4VMuAYrJdlqQFndgbj6WJAXPhaysvBiXefX79upBdQVumgYcdd17gCpjQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^12 || >=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ota-meshi"
-			},
-			"peerDependencies": {
-				"postcss-html": "^1.0.0",
-				"stylelint": ">=14.0.0"
 			}
 		},
 		"node_modules/stylelint-config-recess-order": {
@@ -3805,43 +3667,6 @@
 				"path-type": "^4.0.0"
 			}
 		},
-		"dom-serializer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-			"dev": true,
-			"requires": {
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.2",
-				"entities": "^4.2.0"
-			}
-		},
-		"domelementtype": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-			"dev": true
-		},
-		"domhandler": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-			"dev": true,
-			"requires": {
-				"domelementtype": "^2.3.0"
-			}
-		},
-		"domutils": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-			"integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
-			"dev": true,
-			"requires": {
-				"dom-serializer": "^2.0.0",
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.3"
-			}
-		},
 		"emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -4194,18 +4019,6 @@
 			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
 			"integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
 			"dev": true
-		},
-		"htmlparser2": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-			"integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
-			"dev": true,
-			"requires": {
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.3",
-				"domutils": "^3.0.1",
-				"entities": "^4.4.0"
-			}
 		},
 		"human-signals": {
 			"version": "5.0.0",
@@ -4807,33 +4620,6 @@
 				"source-map-js": "^1.2.1"
 			}
 		},
-		"postcss-html": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-1.7.0.tgz",
-			"integrity": "sha512-MfcMpSUIaR/nNgeVS8AyvyDugXlADjN9AcV7e5rDfrF1wduIAGSkL4q2+wgrZgA3sHVAHLDO9FuauHhZYW2nBw==",
-			"dev": true,
-			"requires": {
-				"htmlparser2": "^8.0.0",
-				"js-tokens": "^9.0.0",
-				"postcss": "^8.4.0",
-				"postcss-safe-parser": "^6.0.0"
-			},
-			"dependencies": {
-				"js-tokens": {
-					"version": "9.0.0",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.0.tgz",
-					"integrity": "sha512-WriZw1luRMlmV3LGJaR6QOJjWwgLUTf89OwT2lUOyjX2dJGBwgmIkbcz+7WFZjrZM635JOIR517++e/67CP9dQ==",
-					"dev": true
-				},
-				"postcss-safe-parser": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
-					"integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
-					"dev": true,
-					"requires": {}
-				}
-			}
-		},
 		"postcss-resolve-nested-selector": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.6.tgz",
@@ -5120,13 +4906,6 @@
 					"dev": true
 				}
 			}
-		},
-		"stylelint-config-html": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-html/-/stylelint-config-html-1.1.0.tgz",
-			"integrity": "sha512-IZv4IVESjKLumUGi+HWeb7skgO6/g4VMuAYrJdlqQFndgbj6WJAXPhaysvBiXefX79upBdQVumgYcdd17gCpjQ==",
-			"dev": true,
-			"requires": {}
 		},
 		"stylelint-config-recess-order": {
 			"version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"format:check": "prettier --check .",
 		"lint": "npm run lint:css && npm run lint:js && npm run lint:md",
 		"lint:fix": "npm run lint:css:fix && npm run lint:js:fix && npm run lint:md:fix",
-		"lint:css": "stylelint --formatter verbose --max-warnings 0 \"**/*.{astro,css,html,php,svelte,vue,xml}\"",
+		"lint:css": "stylelint \"**/*.css\"",
 		"lint:css:fix": "npm run lint:css -- --fix",
 		"lint:js": "eslint --max-warnings 0",
 		"lint:js:fix": "npm run lint:js -- --fix",
@@ -38,7 +38,7 @@
 		"test": "npm run format:check && npm run lint"
 	},
 	"lint-staged": {
-		"(*.astro|*.css|*.html|*.php|*.svelte|*.vue|*.xml)": [
+		"*.css": [
 			"stylelint",
 			"prettier --write"
 		],
@@ -49,7 +49,7 @@
 		"*.md": [
 			"markdownlint-cli2 --fix"
 		],
-		"!(*.astro|*.css|*.html|*.js|*.md|*.php|*.svelte|*.vue|*.xml)": [
+		"!(*.css|*.js|*.md)": [
 			"prettier --write --ignore-unknown"
 		]
 	},
@@ -60,10 +60,8 @@
 		"husky": "9.1.6",
 		"lint-staged": "15.2.10",
 		"markdownlint-cli2": "0.15.0",
-		"postcss-html": "1.7.0",
 		"prettier": "3.3.3",
 		"stylelint": "16.10.0",
-		"stylelint-config-html": "1.1.0",
 		"stylelint-config-recess-order": "5.1.1",
 		"stylelint-config-standard": "36.0.1",
 		"stylelint-plugin-defensive-css": "1.0.4"

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -3,7 +3,6 @@ export default {
 	extends: [
 		// Order matters: later configs take precedence over (override) earlier ones.
 		"stylelint-config-standard",
-		"stylelint-config-html",
 		"stylelint-config-recess-order",
 	],
 	plugins: ["stylelint-plugin-defensive-css"],


### PR DESCRIPTION
This reverts commit daa3fc2b0319f103737dfe0576b5c9b404fb136f.

Using Stylelint in HTML and PHP files for WordPress was causing some strange issues, so better revert it.