### PR TITLE
Stylelint: Report disable comments that aren't scoped to rules

### DIFF
--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -9,6 +9,7 @@ export default {
 	reportDescriptionlessDisables: true,
 	reportInvalidScopeDisables: true,
 	reportNeedlessDisables: true,
+	reportUnscopedDisables: true,
 	rules: {
 		/**
 		 * ----------------------------------------


### PR DESCRIPTION
Option available since [Stylelint v16.11.0](https://github.com/stylelint/stylelint/releases/tag/16.11.0).