### PR TITLE
chore: Configure Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,3 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
   - package-ecosystem: "npm"
@@ -14,3 +9,7 @@ updates:
         patterns:
           - "eslint"
           - "@eslint/js"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
This commit adds a new configuration to `dependabot.yml` to automatically check for and update outdated GitHub Actions on a monthly basis. This helps keep workflows secure and up to date with the latest versions.